### PR TITLE
Fix repository URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@
 ### 1. Cloner le repo
 
 ```bash
-git clone https://github.com/votre-utilisateur/devsync.git
-cd devsync
+git clone https://github.com/akoun-dev/DevSync.git
+cd DevSync


### PR DESCRIPTION
## Summary
- update README clone instructions to reference the actual GitHub repo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850246b3c98832dbe2c894126de0405